### PR TITLE
Connect Task Runner to a local API

### DIFF
--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -12,5 +12,7 @@ services:
         MACHINE_GROUP_NAME: ${MACHINE_GROUP_NAME}
       volumes:
         - ./apptainer:/executer-images
+      extra-hosts:
+        - "host.docker.internal:host-gateway"
       privileged: true
       platform: linux/amd64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,7 @@ services:
         MACHINE_GROUP_NAME: ${MACHINE_GROUP_NAME}
       volumes:
         - ./apptainer:/executer-images
+      extra-hosts:
+        - "host.docker.internal:host-gateway"
       privileged: true
       platform: linux/amd64


### PR DESCRIPTION
This PR adds the support to connect the Task Runner to a local API, pointed out by @rcvalerio. 
On the .env file you should set your `INDUCTIVA_API_URL` as  `http://host.docker.internal:API_PORT`, replacing `API_PORT` with the port attributed to you. 