### PR TITLE
Launch multiple task runners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,17 +6,17 @@ DOCKER_COMPOSE_COMMAND=\
 
 DOCKER_COMPOSE_COMMAND_TASK_RUNNER=\
 	$(DOCKER_COMPOSE_COMMAND) \
-	-p task-runner \
+	-p task-runner$(ID) \
 	-f docker-compose.yml
 
 DOCKER_COMPOSE_COMMAND_TASK_RUNNER_CUDA=\
 	$(DOCKER_COMPOSE_COMMAND) \
-	-p task-runner-cuda \
+	-p task-runner-cuda$(ID) \
 	-f docker-compose.cuda.yml
 
 DOCKER_COMPOSE_COMMAND_TASK_RUNNER_LITE=\
 	$(DOCKER_COMPOSE_COMMAND) \
-	-p task-runner-lite \
+	-p task-runner-lite$(ID) \
 	-f docker-compose.lite.yml
 
 .PHONY: %

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ Build and run the Task Runner with CUDA support:
 make task-runner-cuda-up
 ```
 
+#### Launching more than one Task Runner on the same machine
+To launch more than one Task Runner associated to the same Machine Grup, add the variable `ID=` to 
+For example to launch 3 Task Runners connected to the same try:
+`
+make task-runner-up
+make ID=2 task-runner-up
+make ID=3 task-runner-up
+`
+
 ### Run Simulations
 
 You can now run simulations locally by passing a local machine when you call the `run` function. Try out the following example:

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ make task-runner-cuda-up
 ```
 
 #### Launching more than one Task Runner on the same machine
-To launch more than one Task Runner associated to the same Machine Grup, add the variable `ID=` to 
-For example to launch 3 Task Runners connected to the same try:
-`
+To launch more than one Task Runner associated to the same Machine Group, add argument `ID=` to when calling make.
+For example to launch 3 Task Runners connected to the same Machine Group do:
+```
 make task-runner-up
 make ID=2 task-runner-up
 make ID=3 task-runner-up
-`
+```
 
 ### Run Simulations
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make task-runner-cuda-up
 ```
 
 #### Launching more than one Task Runner on the same machine
-To launch more than one Task Runner associated to the same Machine Group, add argument `ID=` to when calling make.
+To launch more than one Task Runner associated to the same Machine Group, add argument `ID=` when calling make.
 For example to launch 3 Task Runners connected to the same Machine Group do:
 ```
 make task-runner-up

--- a/README.md
+++ b/README.md
@@ -27,29 +27,11 @@ Build and run the docker container:
 make task-runner-up
 ```
 
-#### Lite mode
-Build and run a lighter version of the Task Runner
-
-```
-make task-runner-lite-up
-```
-
-NOTE: The simulators that use openmpi (eg. AmrWind, CaNs) can not be chosen to run simulations in Lite mode. 
-
 #### With GPU access
 Build and run the Task Runner with CUDA support:
 
 ```
 make task-runner-cuda-up
-```
-
-#### Launching more than one Task Runner on the same machine
-To launch more than one Task Runner associated to the same Machine Group, add argument `ID=` when calling make.
-For example to launch 3 Task Runners connected to the same Machine Group do:
-```
-make task-runner-up
-make ID=2 task-runner-up
-make ID=3 task-runner-up
 ```
 
 ### Run Simulations

--- a/README.md
+++ b/README.md
@@ -18,21 +18,23 @@ MACHINE_GROUP_NAME='my-machine-group-name'
 ```
 
 ### Build and Run the application
-The application can be run in two different ways: the fully functional `Normal mode` that takes longer to build, or a lighter `Lite mode` that does not install openmpi.
+The application is run by launching a docker container. The default Task Runner does not access the GPU, but a different container with CUDA support is also available.
 
-#### Normal mode
+#### Task Runner
 Build and run the docker container:
 
 ```
 make task-runner-up
 ```
 
-#### With GPU access
+#### Task Runner with GPU access
 Build and run the Task Runner with CUDA support:
 
 ```
 make task-runner-cuda-up
 ```
+
+Please make sure you have the nvidia drivers installed. 
 
 ### Run Simulations
 
@@ -72,4 +74,34 @@ task = gromacs.run(
 task.wait()
 
 task.download_outputs()
+```
+
+### For developers/contributors
+The following are instructions that can help developers setup the development mode or create scenarios for testing features. 
+
+#### Connect to local API
+If you want connect to an API that is running locally in your `.env` file set the url as:
+
+```
+INDUCTIVA_API_URL=http://host.docker.internal:(api-port)
+``` 
+
+Replacing api-port with the port where the API is exposed. 
+
+#### Lite mode
+To implement and test features that do not require running MPI simulators it is possible to build and run a lighter version of the Task Runner that does not install openmpi by:
+
+```
+make task-runner-lite-up
+```
+
+NOTE: The simulators that use openmpi (eg. AmrWind, CaNs) can not be chosen to run simulations in Lite mode. 
+
+#### Launching more than one Task Runner on the same machine
+To launch more than one Task Runner associated to the same Machine Group, add argument `ID=` when calling make.
+For example to launch 3 Task Runners connected to the same Machine Group do:
+```
+make task-runner-up
+make ID=2 task-runner-up
+make ID=3 task-runner-up
 ```


### PR DESCRIPTION
This PR adds the possibility to launch multiple Task Runners using the `Makefile` on the same machine, as well as instructions on how to do so. 