### PR TITLE
Update swan to allow swanrun or swanexe

### DIFF
--- a/task-runner/task_runner/executers/swan/executer.py
+++ b/task-runner/task_runner/executers/swan/executer.py
@@ -9,6 +9,7 @@ import shutil
 
 class SWANExecuter(executers.BaseExecuter):
     """Executer class for the SWAN simulator."""
+
     def execute(self):
         sim_binary = self.args.command
         input_filename = self.args.input_filename
@@ -29,12 +30,10 @@ class SWANExecuter(executers.BaseExecuter):
             else:
                 cmd_str = f"{sim_binary} -input {input_filename}"
         elif sim_binary == "swan.exe":
-                cmd_str = f"{sim_binary}"
+            cmd_str = f"{sim_binary}"
         else:
             raise ValueError("Invalid sim_binary")
 
-        cmd = executers.Command(cmd_str,
-                                is_mpi=True)
+        cmd = executers.Command(cmd_str, is_mpi=True)
 
         self.run_subprocess(cmd, self.artifacts_dir)
-

--- a/task-runner/task_runner/executers/swan/executer.py
+++ b/task-runner/task_runner/executers/swan/executer.py
@@ -1,10 +1,8 @@
 """Run simulation with SWAN."""
-from task_runner import executers
-from task_runner.executers import mpi_configuration
-from task_runner.utils import loki
-
 import os
 import shutil
+
+from task_runner import executers
 
 
 class SWANExecuter(executers.BaseExecuter):

--- a/task-runner/task_runner/executers/swan/executer.py
+++ b/task-runner/task_runner/executers/swan/executer.py
@@ -3,20 +3,38 @@ from task_runner import executers
 from task_runner.executers import mpi_configuration
 from task_runner.utils import loki
 
+import os
+import shutil
 
-class SWANExecuter(executers.MPIExecuter):
 
-    def __init__(
-        self,
-        working_dir,
-        container_image,
-        mpi_config: mpi_configuration.MPIClusterConfiguration,
-        loki_logger: loki.LokiLogger,
-    ):
-        super().__init__(working_dir=working_dir,
-                         container_image=container_image,
-                         loki_logger=loki_logger,
-                         mpi_config=mpi_config,
-                         sim_binary="swan.exe",
-                         file_type="swn",
-                         sim_specific_input_filename="INPUT")
+class SWANExecuter(executers.BaseExecuter):
+    """Executer class for the SWAN simulator."""
+    def execute(self):
+        sim_binary = self.args.command
+        input_filename = self.args.input_filename
+
+        input_dir = os.path.join(self.working_dir, self.args.sim_dir)
+        shutil.copytree(input_dir, self.artifacts_dir, dirs_exist_ok=True)
+
+        if self.args.n_vcpus:
+            self.mpi_config.extra_args.extend(["-np", f"{self.args.n_vcpus}"])
+
+        if self.args.use_hwthread:
+            self.mpi_config.extra_args.extend(["--use-hwthread-cpus"])
+
+        if sim_binary is "swanrun":
+            if input_filename.endswith(".swn"):
+                #remove the .swn extension
+                cmd_str = f"{sim_binary} -input {input_filename[:-4]}"
+            else:
+                cmd_str = f"{sim_binary} -input {input_filename}"
+        elif sim_binary is "swan.exe":
+                cmd_str = f"{sim_binary}"
+        else:
+            raise ValueError("Invalid sim_binary")
+
+        cmd = executers.Command(cmd_str,
+                                is_mpi=True)
+
+        self.run_subprocess(cmd, self.artifacts_dir)
+

--- a/task-runner/task_runner/executers/swan/executer.py
+++ b/task-runner/task_runner/executers/swan/executer.py
@@ -22,13 +22,13 @@ class SWANExecuter(executers.BaseExecuter):
         if self.args.use_hwthread:
             self.mpi_config.extra_args.extend(["--use-hwthread-cpus"])
 
-        if sim_binary is "swanrun":
+        if sim_binary == "swanrun":
             if input_filename.endswith(".swn"):
                 #remove the .swn extension
                 cmd_str = f"{sim_binary} -input {input_filename[:-4]}"
             else:
                 cmd_str = f"{sim_binary} -input {input_filename}"
-        elif sim_binary is "swan.exe":
+        elif sim_binary == "swan.exe":
                 cmd_str = f"{sim_binary}"
         else:
             raise ValueError("Invalid sim_binary")


### PR DESCRIPTION
https://github.com/inductiva/tasks/issues/492

This PR allows the user to run swanrun or swan.exe.

By default it will use swanrun.

`swanrun` needs the flag -input
`swan.exe` takes no flags but needs the input file to be called INPUT (that should be responsibility of the user).

I had to remove the mpiexecuter since i need to build the command.
