### PR TITLE
Separate task runner by user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DOCKER_COMPOSE_ENV_FILE=.env
-HOSTNAME:=$(shell uname -n) 
+UID=$$(id -u)
+HOSTNAME:=$(shell uname -n)
 
 DOCKER_COMPOSE_COMMAND=\
 	HOSTNAME=$(HOSTNAME) docker compose \
@@ -7,17 +8,17 @@ DOCKER_COMPOSE_COMMAND=\
 
 DOCKER_COMPOSE_COMMAND_TASK_RUNNER=\
 	$(DOCKER_COMPOSE_COMMAND) \
-	-p task-runner \
+	-p task-runner-$(UID) \
 	-f docker-compose.yml
 
 DOCKER_COMPOSE_COMMAND_TASK_RUNNER_CUDA=\
 	$(DOCKER_COMPOSE_COMMAND) \
-	-p task-runner-cuda \
+	-p task-runner-cuda-$(UID) \
 	-f docker-compose.cuda.yml
 
 DOCKER_COMPOSE_COMMAND_TASK_RUNNER_LITE=\
 	$(DOCKER_COMPOSE_COMMAND) \
-	-p task-runner-lite \
+	-p task-runner-lite-$(UID) \
 	-f docker-compose.lite.yml
 
 .PHONY: %


### PR DESCRIPTION
This PR adds the user ID to the docker project the task-runner is running, so that several users can start task runners on the same machine.