### PR TITLE
Prevent double termination

### DIFF
--- a/task-runner/task_runner/cleanup.py
+++ b/task-runner/task_runner/cleanup.py
@@ -73,6 +73,8 @@ class TerminationHandler:
         stopped_tasks = []
         if self.request_handler.is_task_running(
         ) and not self.request_handler.caught_exception:
+            # Check if the task has not caused an exception and is trying
+            # to terminate before assocating it to the ExecuterTerminated event.
             logging.info("Task was being executed: %s.",
                          self.request_handler.task_id)
             self.request_handler.interrupt_task()

--- a/task-runner/task_runner/cleanup.py
+++ b/task-runner/task_runner/cleanup.py
@@ -71,10 +71,7 @@ class TerminationHandler:
             self._termination_logged = True
 
         stopped_tasks = []
-        if self.request_handler.is_task_running(
-        ) and not self.request_handler.caught_exception:
-            # Check if the task has not caused an exception and is trying
-            # to terminate before assocating it to the ExecuterTerminated event.
+        if self.request_handler.is_task_running():
             logging.info("Task was being executed: %s.",
                          self.request_handler.task_id)
             self.request_handler.interrupt_task()

--- a/task-runner/task_runner/cleanup.py
+++ b/task-runner/task_runner/cleanup.py
@@ -71,7 +71,8 @@ class TerminationHandler:
             self._termination_logged = True
 
         stopped_tasks = []
-        if self.request_handler.is_task_running():
+        if self.request_handler.is_task_running(
+        ) and not self.request_handler.caught_exception:
             logging.info("Task was being executed: %s.",
                          self.request_handler.task_id)
             self.request_handler.interrupt_task()

--- a/task-runner/task_runner/task_request_handler.py
+++ b/task-runner/task_runner/task_request_handler.py
@@ -562,6 +562,10 @@ class TaskRequestHandler:
 
     def _pack_output(self) -> int:
         """Compress outputs and store them in the shared drive."""
+        if self.task_workdir is None:
+            logging.error("Working directory not found.")
+            return
+
         output_dir = os.path.join(self.task_workdir, utils.OUTPUT_DIR)
         if not os.path.exists(output_dir):
             logging.error("Output directory not found: %s", output_dir)

--- a/task-runner/task_runner/task_request_handler.py
+++ b/task-runner/task_runner/task_request_handler.py
@@ -168,6 +168,7 @@ class TaskRequestHandler:
         self.task_workdir = None
         self.apptainer_image_path = None
         self.threads = []
+        self.caught_exception = False
         self._message_listener_thread = None
         self._kill_task_thread_queue = None
         self._logger_enabled = threading.Event()
@@ -270,6 +271,7 @@ class TaskRequestHandler:
         # convert to bool because stream_zip is either 't' or 'f'
         self.stream_zip = True if request.get("stream_zip",
                                               "t") == "t" else False
+        self.caught_exception = False
         self.loki_logger = loki.LokiLogger(
             task_id=self.task_id,
             project_id=self.project_id,
@@ -381,6 +383,7 @@ class TaskRequestHandler:
 
         # Catch all exceptions to ensure that we log the error message
         except Exception as e:  # noqa: BLE001
+            self.caught_exception = True
             message = utils.get_exception_root_cause_message(e)
             try:
                 safely_delete = self.save_output()


### PR DESCRIPTION
This PR prevents the Task Runner from emitting the ExecuterTrackerTerminated (associated with a task) while the task is performing the cleanup and has already sent a terminal event. 