### PR TITLE
Fix referencing `safely_delete` var before assignment

### DIFF
--- a/task-runner/task_runner/task_request_handler.py
+++ b/task-runner/task_runner/task_request_handler.py
@@ -281,6 +281,7 @@ class TaskRequestHandler:
         self._kill_task_thread_queue = queue.Queue()
 
         self._log_task_picked_up()
+        safely_delete = False
 
         try:
             self._message_listener_thread = threading.Thread(
@@ -329,7 +330,6 @@ class TaskRequestHandler:
                 return
 
             self.task_workdir = self._setup_working_dir(self.task_dir_remote)
-            safely_delete = False
 
             if self._check_task_killed():
                 self._publish_event(


### PR DESCRIPTION
This PR fixes a bug that caused the `safely_delete` variable to be used before assignment in case of the simulation failing before task directory was setup. 