### PR TITLE
Fix missing terminate event

### DIFF
--- a/task-runner/task_runner/cleanup.py
+++ b/task-runner/task_runner/cleanup.py
@@ -75,7 +75,6 @@ class TerminationHandler:
             logging.info("Task was being executed: %s.",
                          self.request_handler.task_id)
             self.request_handler.interrupt_task()
-            self.request_handler.save_output()
             stopped_tasks.append(self.request_handler.task_id)
 
         self.request_handler.set_shutting_down()
@@ -89,6 +88,9 @@ class TerminationHandler:
             traceback=traceback_str,
         )
         self.event_logger.log(event)
+
+        if self.request_handler.is_task_running():
+            self.request_handler.save_output(force=True)
 
         logging.info("Successfully logged executer tracker termination.")
 

--- a/task-runner/task_runner/task_request_handler.py
+++ b/task-runner/task_runner/task_request_handler.py
@@ -189,21 +189,22 @@ class TaskRequestHandler:
 
         self._kill_task_thread_queue.put(INTERRUPT_MESSAGE)
 
-    def save_output(self, new_task_status=None):
+    def save_output(self, new_task_status=None, force=False):
         output_size = self._pack_output()
-        self._publish_event(
-            events.TaskOutputUploaded(id=self.task_id,
-                                      machine_id=self.executer_uuid,
-                                      new_status=new_task_status,
-                                      output_size=output_size))
+        self._publish_event(events.TaskOutputUploaded(
+            id=self.task_id,
+            machine_id=self.executer_uuid,
+            new_status=new_task_status,
+            output_size=output_size),
+                            force=force)
         return True
 
     def is_task_running(self) -> bool:
         """Checks if a task is currently running."""
         return self.task_id is not None and not self.cleaning_up
 
-    def _publish_event(self, event: events.Event):
-        if not self._shutting_down:
+    def _publish_event(self, event: events.Event, force=False):
+        if force or not self._shutting_down:
             self.event_logger.log(event)
 
     def _post_task_metric(self, metric: str, value: float):
@@ -390,8 +391,6 @@ class TaskRequestHandler:
         except Exception as e:  # noqa: BLE001
             message = utils.get_exception_root_cause_message(e)
             try:
-                safely_delete = self.save_output()
-
                 self._publish_event(
                     events.TaskExecutionFailed(
                         id=self.task_id,
@@ -399,6 +398,9 @@ class TaskRequestHandler:
                         error_message=message,
                         traceback=traceback.format_exc(),
                     ))
+
+                safely_delete = self.save_output()
+
             except Exception as e:  # noqa: BLE001
                 logging.exception("Failed to save output: %s", e)
                 safely_delete = False


### PR DESCRIPTION
This PR fixes inductiva/tasks#595. The termination event is sent before the task runner tries to upload its files to the bucket.