### PR TITLE
Remove invalid characters check from command

### DIFF
--- a/task-runner/task_runner/executers/security.py
+++ b/task-runner/task_runner/executers/security.py
@@ -1,7 +1,5 @@
 """Security checks for the executers."""
 
-import re
-
 
 def check_command_elem_security(cmd_elem):
     """Checks for security issues in a command element."""

--- a/task-runner/task_runner/executers/security.py
+++ b/task-runner/task_runner/executers/security.py
@@ -12,11 +12,3 @@ def check_command_elem_security(cmd_elem):
 
     if cmd_elem == "":
         raise ValueError(f"Command element '{cmd_elem}' is empty.")
-
-    # Assure that command element is not a know operator for concatenating
-    # multiple commands in a single line.
-    # Blacklist: contains ";" or "|" or two "&".
-    pattern = r".*[;|&]{1,2}.*"
-    if re.match(pattern, cmd_elem):
-        raise ValueError(
-            f"Command element '{cmd_elem}' contains invalid characters.")


### PR DESCRIPTION
I removed the check for ; && || because there is a simulator (fvcom) where i need to run `cd run && fvcom ...`