### PR TITLE
gets the working_dir from the client if not provided uses artifacts_dir

### DIFF
--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -12,11 +12,15 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
     def execute(self):
         input_dir = os.path.join(self.working_dir, self.args.sim_dir)
 
-        working_dir = self.args.working_dir or self.artifacts_dir
+        run_subprocess_dir = self.artifacts_dir
+
+        if self.args.run_subprocess_dir:
+            run_subprocess_dir = os.path.join(self.artifacts_dir,
+                                              self.args.run_subprocess_dir)
 
         # Copy the input files to the artifacts directory
         shutil.copytree(input_dir, self.artifacts_dir, dirs_exist_ok=True)
 
         for command in self.args.commands:
             cmd = executers.Command.from_dict(command)
-            self.run_subprocess(cmd, working_dir=working_dir)
+            self.run_subprocess(cmd, working_dir=run_subprocess_dir)

--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -12,9 +12,11 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
     def execute(self):
         input_dir = os.path.join(self.working_dir, self.args.sim_dir)
 
+        working_dir = self.args.working_dir or self.artifacts_dir
+
         # Copy the input files to the artifacts directory
         shutil.copytree(input_dir, self.artifacts_dir, dirs_exist_ok=True)
 
         for command in self.args.commands:
             cmd = executers.Command.from_dict(command)
-            self.run_subprocess(cmd, self.artifacts_dir)
+            self.run_subprocess(cmd, working_dir=working_dir)

--- a/task-runner/task_runner/executers/base_executer.py
+++ b/task-runner/task_runner/executers/base_executer.py
@@ -237,7 +237,8 @@ class BaseExecuter(ABC):
         with open(self.stdout_logs_path, "a", encoding="UTF-8") as stdout, \
             open(self.stderr_logs_path, "a", encoding="UTF-8") as stderr, \
                 open(stdin_path, "r", encoding="UTF-8") as stdin:
-            log_message = f"# COMMAND: {cmd.args}\n"
+            log_message = (f"# COMMAND: {cmd.args}\n"
+                           f"# Working directory: {working_dir}\n")
             self.loki_logger.log_text(log_message, io_type=loki.IOTypes.COMMAND)
             log_message += "\n"
             stdout.write(log_message)

--- a/task-runner/tests/unit/test_task_request_handler.py
+++ b/task-runner/tests/unit/test_task_request_handler.py
@@ -75,6 +75,7 @@ def download_input_side_effect(
 
     task_request_payload = {
         "sim_dir": "sim_dir",
+        "run_subprocess_dir": None,
         "container_image": "unused",
         "commands": [{
             "cmd": command,


### PR DESCRIPTION
Doing `cp X && program` does not work. So i'll allow the python client to pick the working_dir.

If no working_dir provided it will run the commands on the artifacts_dir