### PR TITLE
fix-bug-with-run_subprocess_dir

### DIFF
--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -14,7 +14,8 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
 
         run_subprocess_dir = self.artifacts_dir
 
-        if self.args.run_subprocess_dir:
+        if hasattr(self.args,
+                   'run_subprocess_dir') and self.args.run_subprocess_dir:
             run_subprocess_dir = os.path.join(self.artifacts_dir,
                                               self.args.run_subprocess_dir)
 


### PR DESCRIPTION
Before checking subprocess_dir we need to check if args has the attribute.