### PR TITLE
Add file-tracker folder to build action

### DIFF
--- a/.github/workflows/trigger-build-vm-image.yml
+++ b/.github/workflows/trigger-build-vm-image.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'common/**'
       - 'task-runner/**'
+      - 'file-tracker/**'
 
 jobs:
   trigger-build-install-image:


### PR DESCRIPTION
This PR adds the `file-tracker` folder to the action to build the task-runner image