### PR TITLE
Simplify docker run command

### DIFF
--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -69,6 +69,8 @@ jobs:
           tags: ${{ steps.meta-task-runner.outputs.tags }}
           labels: |
             ${{ steps.meta-task-runner.outputs.labels }}
+          build-args: |
+            API_URL=${{ github.ref == 'refs/heads/main' && 'https://api.inductiva.ai' || 'https://api-dev.inductiva.ai' }}
 
       # Build and push file-tracker
       - name: Build and push file-tracker to Docker Hub
@@ -81,4 +83,6 @@ jobs:
           tags: ${{ steps.meta-file-tracker.outputs.tags }}
           labels: |
             ${{ steps.meta-file-tracker.outputs.labels }}
+          build-args: |
+            API_URL=${{ github.ref == 'refs/heads/main' && 'https://api.inductiva.ai' || 'https://api-dev.inductiva.ai' }}
 

--- a/file-tracker/Dockerfile
+++ b/file-tracker/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9
 
+ARG API_URL=https://api.inductiva.ai
+ENV API_URL=${API_URL}
+
 # Install the package dependencies in the requirements file.
 COPY /file-tracker/requirements.txt /requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /requirements.txt

--- a/task-runner/Dockerfile
+++ b/task-runner/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.9
 
 ENV LOCAL_MODE=true
+ENV EXECUTER_IMAGES_DIR=/executer-images
 
 ARG API_URL=https://api.inductiva.ai
 ENV API_URL=${API_URL}

--- a/task-runner/Dockerfile
+++ b/task-runner/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.9
 
-ENV LOCAL_MODE true
+ENV LOCAL_MODE=true
+
+ARG API_URL=https://api.inductiva.ai
+ENV API_URL=${API_URL}
 
 RUN apt-get update && apt-get install -y wget
 RUN cd /tmp \

--- a/task-runner/Dockerfile.lite
+++ b/task-runner/Dockerfile.lite
@@ -2,9 +2,6 @@ FROM python:3.9
 
 ENV LOCAL_MODE true
 
-ARG API_URL=https://api.inductiva.ai
-ENV API_URL=${API_URL}
-
 RUN apt-get update && apt-get install -y wget
 RUN cd /tmp \
     && wget https://github.com/apptainer/apptainer/releases/download/v1.3.3/apptainer_1.3.3_amd64.deb \

--- a/task-runner/Dockerfile.lite
+++ b/task-runner/Dockerfile.lite
@@ -2,6 +2,9 @@ FROM python:3.9
 
 ENV LOCAL_MODE true
 
+ARG API_URL=https://api.inductiva.ai
+ENV API_URL=${API_URL}
+
 RUN apt-get update && apt-get install -y wget
 RUN cd /tmp \
     && wget https://github.com/apptainer/apptainer/releases/download/v1.3.3/apptainer_1.3.3_amd64.deb \


### PR DESCRIPTION
This PR simplifies the docker run command of the task runner by removing 2 env variables from the runtime environment and passing them during build. 