### PR TITLE
Get messages after kill

### DIFF
--- a/task-runner/task_runner/task_request_handler.py
+++ b/task-runner/task_runner/task_request_handler.py
@@ -73,7 +73,6 @@ def task_message_listener_loop(
 
         elif message == KILL_MESSAGE:
             kill_task_thread_queue.put(KILL_MESSAGE)
-            return
 
         elif message == ENABLE_LOGGING_STREAM_MESSAGE:
             logger_enabled.set()


### PR DESCRIPTION
This PR stops the message loop from returning after receiving task kill. This results in the API being aware of the task-runner while files are uploading