### PR TITLE
Terminate file-tracker after mg.terminate()

### DIFF
--- a/file-tracker/file_tracker/connection_manager.py
+++ b/file-tracker/file_tracker/connection_manager.py
@@ -13,6 +13,8 @@ class ConnectionManager:
         self._user_api_key = user_api_key
         self._ice_url = ice_url
         self._headers = {"X-API-Key": self._user_api_key}
+        self.loop = None
+        self.connections = []
 
     @classmethod
     def from_env(cls):
@@ -23,9 +25,8 @@ class ConnectionManager:
         )
 
     async def listen(self, task_id):
-        self.running = True
         self.connections = []
-        asyncio.create_task(self._listen_loop(task_id))
+        self.loop = asyncio.create_task(self._listen_loop(task_id))
 
     def _request_data(self, task_id, receiver_id=None, type=None, sdp=None):
         return {
@@ -43,7 +44,7 @@ class ConnectionManager:
                                json=self._request_data(task_id),
                                headers=self._headers)
 
-            while self.running:
+            while True:
                 logging.info("Listening for connections")
                 async with session.get(url + f"message?client={task_id}",
                                        headers=self._headers) as resp:
@@ -68,9 +69,10 @@ class ConnectionManager:
                         logging.error("Failed to get messages: %s", await
                                       resp.text())
                         await asyncio.sleep(5)
-            logging.info("Stopped listening for messages.")
 
     async def close(self):
-        self.running = False
+        if self.loop:
+            self.loop.cancel()
         for connection in self.connections:
             await connection.close()
+        logging.info("Connection manager closed")

--- a/task-runner/task_runner/api_file_tracker.py
+++ b/task-runner/task_runner/api_file_tracker.py
@@ -29,6 +29,11 @@ class ApiFileTracker:
             asyncio.run(self._message(message))
             self.started = False
 
+    def terminate(self):
+        logging.info("Terminating task streaming")
+        message = "terminate"
+        asyncio.run(self._message(message))
+
     async def _connect(self, num_retries=3):
         while num_retries > 0:
             try:

--- a/task-runner/task_runner/main.py
+++ b/task-runner/task_runner/main.py
@@ -172,6 +172,8 @@ def main(_):
 
             monitoring_flag = False
 
+    api_file_tracker.terminate()
+
 
 if __name__ == "__main__":
     logging.set_verbosity(logging.INFO)


### PR DESCRIPTION
This PR terminate file-tracker after the task-runner mg is terminated by user.