### PR TITLE
Keep old local MGs

### DIFF
--- a/task-runner/task_runner/api_client.py
+++ b/task-runner/task_runner/api_client.py
@@ -263,7 +263,7 @@ class ApiClient:
                 f"Failed to start local machine group: {resp.json()['detail']}")
         return resp.json()["id"]
 
-    def get_machine_group_id_by_name(
+    def get_started_machine_group_id_by_name(
             self, machine_group_name: str) -> Optional[uuid.UUID]:
         resp = self._request(
             "GET",
@@ -271,6 +271,9 @@ class ApiClient:
         )
 
         if resp.status_code != HTTPStatus.SUCCESS.value:
+            return
+
+        if resp.json()["status"] != "started":
             return
 
         return resp.json().get("id")

--- a/task-runner/task_runner/api_client.py
+++ b/task-runner/task_runner/api_client.py
@@ -257,10 +257,10 @@ class ApiClient:
         )
 
         if resp.status_code != HTTPStatus.SUCCESS.value:
-            return
+            return None
 
         if resp.json()["status"] != "started":
-            return
+            return None
 
         return resp.json().get("id")
 

--- a/task-runner/task_runner/api_client.py
+++ b/task-runner/task_runner/api_client.py
@@ -249,20 +249,6 @@ class ApiClient:
                 f"Failed to create local machine group: {resp.json()}")
         return resp.json()["id"]
 
-    def start_local_machine_group(self, machine_group_id: uuid.UUID):
-        resp = self._request(
-            "POST",
-            "/compute/group/start",
-            json={
-                "id": machine_group_id,
-            },
-        )
-
-        if resp.status_code != HTTPStatus.SUCCESS.value:
-            raise RuntimeError(
-                f"Failed to start local machine group: {resp.json()['detail']}")
-        return resp.json()["id"]
-
     def get_started_machine_group_id_by_name(
             self, machine_group_name: str) -> Optional[uuid.UUID]:
         resp = self._request(

--- a/task-runner/task_runner/machine_group.py
+++ b/task-runner/task_runner/machine_group.py
@@ -24,9 +24,10 @@ class MachineGroupInfo:
             logging.info("Specified machine group: %s", machine_group_info.id)
             return machine_group_info
 
-        if machine_group_info.name and (machine_group_id :=
-                                        api_client.get_machine_group_id_by_name(
-                                            machine_group_info.name)):
+        if machine_group_info.name and (
+                machine_group_id :=
+                api_client.get_started_machine_group_id_by_name(
+                    machine_group_info.name)):
             logging.info("Specified machine group exists: %s",
                          machine_group_info.name)
             machine_group_info.id = machine_group_id

--- a/task-runner/task_runner/main.py
+++ b/task-runner/task_runner/main.py
@@ -77,9 +77,6 @@ def main(_):
         machine_group_info = task_runner.MachineGroupInfo.from_api(api_client)
         machine_group_id = machine_group_info.id
         local_mode = machine_group_info.local_mode
-
-        if local_mode:
-            api_client.start_local_machine_group(machine_group_id)
     except RuntimeError as e:
         logging.error(str(e))
         api_file_tracker.terminate()


### PR DESCRIPTION
This PR changes the way local task-runners are started:
- Mgs are now started on creation
- If a machine group with the same name is already running, the task-runner is added to it. 