### PR TITLE
Task Outputs No longer include inputs 

### DIFF
--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -7,6 +7,7 @@ import time
 from task_runner import executers
 from task_runner.utils import files
 
+REMOVE_UNCHANGED_FILES_FLAG = os.getenv("REMOVE_BEFORE_TIME_FLAG", True)
 
 class ArbitraryCommandsExecuter(executers.BaseExecuter):
     """Concrete implementation of an Executer to run arbitrary commands."""
@@ -32,5 +33,6 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
             self.run_subprocess(cmd, working_dir=run_subprocess_dir)
         
         # Remove files that were not modified or created during the simulation
-        files.remove_before_time(directory=self.artifacts_dir,
-                                 reference_time=start_time)
+        if REMOVE_UNCHANGED_FILES_FLAG:
+            files.remove_before_time(directory=self.artifacts_dir,
+                                     reference_time=start_time)

--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -2,7 +2,6 @@
 
 import os
 import shutil
-import time
 
 from task_runner import executers
 from task_runner.utils import files

--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -25,7 +25,7 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         shutil.copytree(input_dir, self.artifacts_dir, dirs_exist_ok=True)
 
         # Save this timestamp to detect which files were created or modified
-        start_time_ns = time.perf_counter()
+        start_time_ns = time.time_ns()
 
         try:
             for command in self.args.commands:

--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -7,7 +7,6 @@ import time
 from task_runner import executers
 from task_runner.utils import files
 
-REMOVE_UNCHANGED_FILES_FLAG = os.getenv("REMOVE_BEFORE_TIME_FLAG", True)
 
 class ArbitraryCommandsExecuter(executers.BaseExecuter):
     """Concrete implementation of an Executer to run arbitrary commands."""
@@ -31,8 +30,7 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         for command in self.args.commands:
             cmd = executers.Command.from_dict(command)
             self.run_subprocess(cmd, working_dir=run_subprocess_dir)
-        
+
         # Remove files that were not modified or created during the simulation
-        if REMOVE_UNCHANGED_FILES_FLAG:
-            files.remove_before_time(directory=self.artifacts_dir,
-                                     reference_time=start_time)
+        files.remove_before_time(directory=self.artifacts_dir,
+                                 reference_time=start_time)

--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -25,7 +25,7 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         shutil.copytree(input_dir, self.artifacts_dir, dirs_exist_ok=True)
 
         # Save this timestamp to detect which files were created or modified
-        start_time = time.time()
+        start_time_ns = time.time_ns()
 
         try:
             for command in self.args.commands:
@@ -34,4 +34,4 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         finally:
             # Remove files that were not modified or created
             files.remove_before_time(directory=self.artifacts_dir,
-                                     reference_time=start_time)
+                                     reference_time_ns=start_time_ns)

--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -25,7 +25,7 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         shutil.copytree(input_dir, self.artifacts_dir, dirs_exist_ok=True)
 
         # Save this timestamp to detect which files were created or modified
-        start_time_ns = time.time_ns()
+        start_time_ms = time.time() * 1000
 
         try:
             for command in self.args.commands:
@@ -34,4 +34,4 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         finally:
             # Remove files that were not modified or created
             files.remove_before_time(directory=self.artifacts_dir,
-                                     reference_time_ns=start_time_ns)
+                                     reference_time_ms=start_time_ms)

--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -25,12 +25,13 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         shutil.copytree(input_dir, self.artifacts_dir, dirs_exist_ok=True)
 
         # Save this timestamp to detect which files were created or modified
-        start_time = time.time()
+        start_time_ns = time.time_ns()
 
-        for command in self.args.commands:
-            cmd = executers.Command.from_dict(command)
-            self.run_subprocess(cmd, working_dir=run_subprocess_dir)
-
-        # Remove files that were not modified or created during the simulation
-        files.remove_before_time(directory=self.artifacts_dir,
-                                 reference_time=start_time)
+        try:
+            for command in self.args.commands:
+                cmd = executers.Command.from_dict(command)
+                self.run_subprocess(cmd, working_dir=run_subprocess_dir)
+        finally:
+            # Remove files that were not modified or created
+            files.remove_before_time(directory=self.artifacts_dir,
+                                     reference_time_ns=start_time_ns)

--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -2,8 +2,10 @@
 
 import os
 import shutil
+import time
 
 from task_runner import executers
+from task_runner.utils import files
 
 
 class ArbitraryCommandsExecuter(executers.BaseExecuter):
@@ -22,6 +24,13 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         # Copy the input files to the artifacts directory
         shutil.copytree(input_dir, self.artifacts_dir, dirs_exist_ok=True)
 
+        # Save this timestamp to detect which files were created or modified
+        start_time = time.time()
+
         for command in self.args.commands:
             cmd = executers.Command.from_dict(command)
             self.run_subprocess(cmd, working_dir=run_subprocess_dir)
+        
+        # Remove files that were not modified or created during the simulation
+        files.remove_before_time(directory=self.artifacts_dir,
+                                 reference_time=start_time)

--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -25,7 +25,7 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         shutil.copytree(input_dir, self.artifacts_dir, dirs_exist_ok=True)
 
         # Save this timestamp to detect which files were created or modified
-        start_time_ms = time.time() * 1000
+        start_time_ns = time.time_ns()
 
         try:
             for command in self.args.commands:
@@ -34,4 +34,4 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         finally:
             # Remove files that were not modified or created
             files.remove_before_time(directory=self.artifacts_dir,
-                                     reference_time_ms=start_time_ms)
+                                     reference_time_ns=start_time_ns)

--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -25,7 +25,7 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         shutil.copytree(input_dir, self.artifacts_dir, dirs_exist_ok=True)
 
         # Save this timestamp to detect which files were created or modified
-        start_time_ns = time.time_ns()
+        timestamp = files.get_most_recent_timestamp(self.artifacts_dir)
 
         try:
             for command in self.args.commands:
@@ -34,4 +34,4 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         finally:
             # Remove files that were not modified or created
             files.remove_before_time(directory=self.artifacts_dir,
-                                     reference_time_ns=start_time_ns)
+                                     reference_time_ns=timestamp)

--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -25,7 +25,7 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         shutil.copytree(input_dir, self.artifacts_dir, dirs_exist_ok=True)
 
         # Save this timestamp to detect which files were created or modified
-        start_time_ns = time.time_ns()
+        start_time_ns = time.perf_counter()
 
         try:
             for command in self.args.commands:

--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -25,7 +25,7 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         shutil.copytree(input_dir, self.artifacts_dir, dirs_exist_ok=True)
 
         # Save this timestamp to detect which files were created or modified
-        start_time_ns = time.time_ns()
+        start_time = time.time()
 
         try:
             for command in self.args.commands:
@@ -34,4 +34,4 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         finally:
             # Remove files that were not modified or created
             files.remove_before_time(directory=self.artifacts_dir,
-                                     reference_time_ns=start_time_ns)
+                                     reference_time=start_time)

--- a/task-runner/task_runner/utils/files.py
+++ b/task-runner/task_runner/utils/files.py
@@ -305,7 +305,7 @@ def extract_subfolder_and_cleanup(zip_path, subfolder, extract_to):
     os.remove(zip_path)
 
 
-def remove_before_time(directory: str, reference_time_ms: float):
+def remove_before_time(directory: str, reference_time_ns: float):
     """
     Remove files in the specified directory that have a modification or
     creation time earlier than the given reference time.
@@ -317,12 +317,12 @@ def remove_before_time(directory: str, reference_time_ms: float):
     removed = []
     for file in directory.iterdir():
         if file.is_dir():
-            removed.extend(remove_before_time(file, reference_time_ms))
+            removed.extend(remove_before_time(file, reference_time_ns))
             continue
 
         file_stat = file.stat()
-        if file_stat.st_mtime * 1_000_000 > reference_time_ms or \
-           file_stat.st_ctime * 1_000_000 > reference_time_ms:
+        if file_stat.st_mtime_ns > reference_time_ns or \
+           file_stat.st_ctime_ns > reference_time_ns:
             continue
 
         file.unlink()

--- a/task-runner/task_runner/utils/files.py
+++ b/task-runner/task_runner/utils/files.py
@@ -313,14 +313,14 @@ def get_directory_filenames(directory_name: str) -> List[str]:
     ]
 
 
-def get_most_recent_timestamp(directory_name: str) -> float:
+def get_most_recent_timestamp(directory_name: str) -> Optional[float]:
 
     def _most_recent_timestamp(filename: str) -> float:
         stat = os.stat(filename)
         return max(stat.st_ctime_ns, stat.st_mtime_ns)
 
     filenames = get_directory_filenames(directory_name)
-    return max(map(_most_recent_timestamp, filenames))
+    return max(map(_most_recent_timestamp, filenames), default=None)
 
 
 def remove_before_time(directory: str, reference_time_ns: float):

--- a/task-runner/task_runner/utils/files.py
+++ b/task-runner/task_runner/utils/files.py
@@ -1,5 +1,6 @@
 """File related utility functions."""
 import os
+import pathlib
 import shutil
 import stat
 import subprocess
@@ -302,3 +303,29 @@ def extract_subfolder_and_cleanup(zip_path, subfolder, extract_to):
 
     # Remove the original ZIP file
     os.remove(zip_path)
+
+
+def remove_before_time(directory: str, reference_time: float):
+    """
+    Remove files in the specified directory that have a modification or
+    creation time earlier than the given reference time.
+    """
+    directory = pathlib.Path(directory)
+    if not directory.is_dir():
+        raise ValueError(f"Not a directory: '{directory}'.")
+    
+    removed = []
+    for file in directory.iterdir():
+        if file.is_dir():
+            removed.extend(remove_before_time(file, reference_time))
+            continue
+
+        file_stat = file.stat()
+        if file_stat.st_mtime > reference_time or \
+           file_stat.st_ctime > reference_time:
+            continue
+
+        file.unlink()
+        removed.append(file)
+
+    return removed

--- a/task-runner/task_runner/utils/files.py
+++ b/task-runner/task_runner/utils/files.py
@@ -313,7 +313,7 @@ def remove_before_time(directory: str, reference_time: float):
     directory = pathlib.Path(directory)
     if not directory.is_dir():
         raise ValueError(f"Not a directory: '{directory}'.")
-    
+
     removed = []
     for file in directory.iterdir():
         if file.is_dir():

--- a/task-runner/task_runner/utils/files.py
+++ b/task-runner/task_runner/utils/files.py
@@ -305,7 +305,7 @@ def extract_subfolder_and_cleanup(zip_path, subfolder, extract_to):
     os.remove(zip_path)
 
 
-def remove_before_time(directory: str, reference_time_ns: float):
+def remove_before_time(directory: str, reference_time: float):
     """
     Remove files in the specified directory that have a modification or
     creation time earlier than the given reference time.
@@ -317,12 +317,12 @@ def remove_before_time(directory: str, reference_time_ns: float):
     removed = []
     for file in directory.iterdir():
         if file.is_dir():
-            removed.extend(remove_before_time(file, reference_time_ns))
+            removed.extend(remove_before_time(file, reference_time))
             continue
 
         file_stat = file.stat()
-        if file_stat.st_mtime_ns > reference_time_ns or \
-           file_stat.st_ctime_ns > reference_time_ns:
+        if file_stat.st_mtime > reference_time or \
+           file_stat.st_ctime > reference_time:
             continue
 
         file.unlink()

--- a/task-runner/task_runner/utils/files.py
+++ b/task-runner/task_runner/utils/files.py
@@ -305,7 +305,7 @@ def extract_subfolder_and_cleanup(zip_path, subfolder, extract_to):
     os.remove(zip_path)
 
 
-def remove_before_time(directory: str, reference_time: float):
+def remove_before_time(directory: str, reference_time_ns: float):
     """
     Remove files in the specified directory that have a modification or
     creation time earlier than the given reference time.
@@ -317,12 +317,12 @@ def remove_before_time(directory: str, reference_time: float):
     removed = []
     for file in directory.iterdir():
         if file.is_dir():
-            removed.extend(remove_before_time(file, reference_time))
+            removed.extend(remove_before_time(file, reference_time_ns))
             continue
 
         file_stat = file.stat()
-        if file_stat.st_mtime > reference_time or \
-           file_stat.st_ctime > reference_time:
+        if file_stat.st_mtime_ns > reference_time_ns or \
+           file_stat.st_ctime_ns > reference_time_ns:
             continue
 
         file.unlink()

--- a/task-runner/task_runner/utils/files.py
+++ b/task-runner/task_runner/utils/files.py
@@ -314,9 +314,11 @@ def get_directory_filenames(directory_name: str) -> List[str]:
 
 
 def get_most_recent_timestamp(directory_name: str) -> float:
+
     def _most_recent_timestamp(filename: str) -> float:
         stat = os.stat(filename)
         return max(stat.st_ctime_ns, stat.st_mtime_ns)
+
     filenames = get_directory_filenames(directory_name)
     return _most_recent_timestamp(max(filenames, key=_most_recent_timestamp))
 

--- a/task-runner/task_runner/utils/files.py
+++ b/task-runner/task_runner/utils/files.py
@@ -320,7 +320,7 @@ def get_most_recent_timestamp(directory_name: str) -> float:
         return max(stat.st_ctime_ns, stat.st_mtime_ns)
 
     filenames = get_directory_filenames(directory_name)
-    return _most_recent_timestamp(max(filenames, key=_most_recent_timestamp))
+    return max(map(_most_recent_timestamp, filenames))
 
 
 def remove_before_time(directory: str, reference_time_ns: float):

--- a/task-runner/task_runner/utils/files.py
+++ b/task-runner/task_runner/utils/files.py
@@ -305,7 +305,7 @@ def extract_subfolder_and_cleanup(zip_path, subfolder, extract_to):
     os.remove(zip_path)
 
 
-def remove_before_time(directory: str, reference_time_ns: float):
+def remove_before_time(directory: str, reference_time_ms: float):
     """
     Remove files in the specified directory that have a modification or
     creation time earlier than the given reference time.
@@ -317,12 +317,12 @@ def remove_before_time(directory: str, reference_time_ns: float):
     removed = []
     for file in directory.iterdir():
         if file.is_dir():
-            removed.extend(remove_before_time(file, reference_time_ns))
+            removed.extend(remove_before_time(file, reference_time_ms))
             continue
 
         file_stat = file.stat()
-        if file_stat.st_mtime_ns > reference_time_ns or \
-           file_stat.st_ctime_ns > reference_time_ns:
+        if file_stat.st_mtime * 1_000_000 > reference_time_ms or \
+           file_stat.st_ctime * 1_000_000 > reference_time_ms:
             continue
 
         file.unlink()

--- a/task-runner/task_runner/utils/files.py
+++ b/task-runner/task_runner/utils/files.py
@@ -7,7 +7,7 @@ import subprocess
 import tempfile
 import zipfile
 import zlib
-from typing import Optional
+from typing import List, Optional
 
 import stream_zip
 from absl import logging
@@ -303,6 +303,22 @@ def extract_subfolder_and_cleanup(zip_path, subfolder, extract_to):
 
     # Remove the original ZIP file
     os.remove(zip_path)
+
+
+def get_directory_filenames(directory_name: str) -> List[str]:
+    return [
+        os.path.join(path, filename)
+        for path, _, filenames in os.walk(directory_name)
+        for filename in filenames
+    ]
+
+
+def get_most_recent_timestamp(directory_name: str) -> float:
+    def _most_recent_timestamp(filename: str) -> float:
+        stat = os.stat(filename)
+        return max(stat.st_ctime_ns, stat.st_mtime_ns)
+    filenames = get_directory_filenames(directory_name)
+    return _most_recent_timestamp(max(filenames, key=_most_recent_timestamp))
 
 
 def remove_before_time(directory: str, reference_time_ns: float):

--- a/task-runner/tests/unit/test_files.py
+++ b/task-runner/tests/unit/test_files.py
@@ -35,22 +35,24 @@ def fixture_directory():
     temporary_directory.cleanup()
 
 
+def get_directory_filenames(directory_name):
+    return [
+        os.path.join(path, filename)
+        for path, _, filenames in os.walk(directory_name)
+        for filename in filenames
+    ]
+
+
 def test_remove_before_time_without_file_changes(directory):
     start_time_ns = time.time_ns()
     removed = files.remove_before_time(directory=directory.name,
                                        reference_time_ns=start_time_ns)
+    after = get_directory_filenames(directory_name=directory.name)
     assert len(removed) == 5
+    assert len(after) == 0
 
 
 def test_remove_before_time_with_file_changes(directory):
-
-    def get_directory_filenames(directory_name):
-        return [
-            os.path.join(path, filename)
-            for path, _, filenames in os.walk(directory_name)
-            for filename in filenames
-        ]
-
     start_time_ns = time.time_ns()
 
     filenames = get_directory_filenames(directory_name=directory.name)

--- a/task-runner/tests/unit/test_files.py
+++ b/task-runner/tests/unit/test_files.py
@@ -36,9 +36,9 @@ def fixture_directory():
 
 
 def test_remove_before_time_without_file_changes(directory):
-    start_time = time.time()
+    start_time_ns = time.time_ns()
     removed = files.remove_before_time(directory=directory.name,
-                                       reference_time=start_time)
+                                       reference_time_ns=start_time_ns)
     assert len(removed) == 5
 
 
@@ -47,11 +47,11 @@ def test_remove_before_time_with_file_changes(directory):
     def get_directory_filenames(directory_name):
         return [
             os.path.join(path, filename)
-            for path, _, filenames in os.walk(directory)
+            for path, _, filenames in os.walk(directory_name)
             for filename in filenames
         ]
 
-    start_time = time.time()
+    start_time_ns = time.time_ns()
 
     filenames = get_directory_filenames(directory_name=directory.name)
 
@@ -65,7 +65,7 @@ def test_remove_before_time_with_file_changes(directory):
         file.write("\n")
 
     removed = files.remove_before_time(directory=directory.name,
-                                       reference_time=start_time)
+                                       reference_time_ns=start_time_ns)
     assert len(removed) == 3
 
     filenames = get_directory_filenames(directory_name=directory.name)

--- a/task-runner/tests/unit/test_files.py
+++ b/task-runner/tests/unit/test_files.py
@@ -21,7 +21,7 @@ def fixture_directory():
             with open(file_path, 'w', encoding="utf-8") as f:
                 f.write(random_string())
 
-    temporary_directory = tempfile.TemporaryDirectory(delete=False)
+    temporary_directory = tempfile.TemporaryDirectory()
 
     create_random_files(temporary_directory.name, 3)
 

--- a/task-runner/tests/unit/test_files.py
+++ b/task-runner/tests/unit/test_files.py
@@ -48,9 +48,9 @@ def test_remove_before_time_without_file_changes(directory):
     Test that all files in the directory are removed when no files are
     modified or created after the reference time.
     """
-    start_time_ns = time.time_ns()
+    start_time = time.time()
     removed = files.remove_before_time(directory=directory.name,
-                                       reference_time_ns=start_time_ns)
+                                       reference_time=start_time)
     after = get_directory_filenames(directory_name=directory.name)
     assert len(removed) == 5
     assert len(after) == 0
@@ -61,7 +61,7 @@ def test_remove_before_time_with_file_changes(directory):
     Test that only files created or modified after the reference time remain in 
     the directory.
     """
-    start_time_ns = time.time_ns()
+    start_time = time.time()
 
     filenames = get_directory_filenames(directory_name=directory.name)
 
@@ -75,7 +75,7 @@ def test_remove_before_time_with_file_changes(directory):
         file.write("\n")
 
     removed = files.remove_before_time(directory=directory.name,
-                                       reference_time_ns=start_time_ns)
+                                       reference_time=start_time)
     assert len(removed) == 3
 
     filenames = get_directory_filenames(directory_name=directory.name)

--- a/task-runner/tests/unit/test_files.py
+++ b/task-runner/tests/unit/test_files.py
@@ -48,9 +48,9 @@ def test_remove_before_time_without_file_changes(directory):
     Test that all files in the directory are removed when no files are
     modified or created after the reference time.
     """
-    start_time = time.time()
+    start_time_ns = time.time_ns()
     removed = files.remove_before_time(directory=directory.name,
-                                       reference_time=start_time)
+                                       reference_time_ns=start_time_ns)
     after = get_directory_filenames(directory_name=directory.name)
     assert len(removed) == 5
     assert len(after) == 0
@@ -61,7 +61,7 @@ def test_remove_before_time_with_file_changes(directory):
     Test that only files created or modified after the reference time remain in 
     the directory.
     """
-    start_time = time.time()
+    start_time_ns = time.time_ns()
 
     filenames = get_directory_filenames(directory_name=directory.name)
 
@@ -75,7 +75,7 @@ def test_remove_before_time_with_file_changes(directory):
         file.write("\n")
 
     removed = files.remove_before_time(directory=directory.name,
-                                       reference_time=start_time)
+                                       reference_time_ns=start_time_ns)
     assert len(removed) == 3
 
     filenames = get_directory_filenames(directory_name=directory.name)

--- a/task-runner/tests/unit/test_files.py
+++ b/task-runner/tests/unit/test_files.py
@@ -48,7 +48,7 @@ def test_remove_before_time_without_file_changes(directory):
     Test that all files in the directory are removed when no files are
     modified or created after the reference time.
     """
-    start_time_ns = time.time_ns()
+    start_time_ns = time.perf_counter()
     removed = files.remove_before_time(directory=directory.name,
                                        reference_time_ns=start_time_ns)
     after = get_directory_filenames(directory_name=directory.name)
@@ -61,7 +61,7 @@ def test_remove_before_time_with_file_changes(directory):
     Test that only files created or modified after the reference time remain in 
     the directory.
     """
-    start_time_ns = time.time_ns()
+    start_time_ns = time.perf_counter()
 
     filenames = get_directory_filenames(directory_name=directory.name)
 

--- a/task-runner/tests/unit/test_files.py
+++ b/task-runner/tests/unit/test_files.py
@@ -42,13 +42,18 @@ def test_remove_before_time_without_file_changes(directory):
 
 
 def test_remove_before_time_with_file_changes(directory):
+
+    def get_directory_filenames(directory_name):
+        return [
+            os.path.join(path, filename)
+            for path, _, filenames in os.walk(directory)
+            for filename in filenames
+        ]
+
     start_time = time.time()
 
-    filenames = [
-        os.path.join(path, filename)
-        for path, _, filenames in os.walk(directory.name)
-        for filename in filenames
-    ]
+    filenames = get_directory_filenames(directory_name=directory.name)
+    
     modified_files = [filenames[0], filenames[-1]]
     for modified_file in modified_files:
         with open(modified_file, "a") as file:
@@ -62,11 +67,7 @@ def test_remove_before_time_with_file_changes(directory):
                                        reference_time=start_time)
     assert len(removed) == 3
 
-    filenames = [
-        os.path.join(path, filename)
-        for path, _, filenames in os.walk(directory.name)
-        for filename in filenames
-    ]
+    filenames = get_directory_filenames(directory_name=directory.name)
 
     assert created_file in filenames
     assert modified_files[0] in filenames

--- a/task-runner/tests/unit/test_files.py
+++ b/task-runner/tests/unit/test_files.py
@@ -48,9 +48,9 @@ def test_remove_before_time_without_file_changes(directory):
     Test that all files in the directory are removed when no files are
     modified or created after the reference time.
     """
-    start_time_ms = time.time() * 1_000_000
+    start_time_ns = time.time_ns()
     removed = files.remove_before_time(directory=directory.name,
-                                       reference_time_ms=start_time_ms)
+                                       reference_time_ns=start_time_ns)
     after = get_directory_filenames(directory_name=directory.name)
     assert len(removed) == 5
     assert len(after) == 0
@@ -61,7 +61,7 @@ def test_remove_before_time_with_file_changes(directory):
     Test that only files created or modified after the reference time remain in 
     the directory.
     """
-    start_time_ms = time.time() * 1_000_000
+    start_time_ns = time.time_ns()
 
     filenames = get_directory_filenames(directory_name=directory.name)
 
@@ -75,7 +75,7 @@ def test_remove_before_time_with_file_changes(directory):
         file.write("\n")
 
     removed = files.remove_before_time(directory=directory.name,
-                                       reference_time_ms=start_time_ms)
+                                       reference_time_ns=start_time_ns)
     assert len(removed) == 3
 
     filenames = get_directory_filenames(directory_name=directory.name)

--- a/task-runner/tests/unit/test_files.py
+++ b/task-runner/tests/unit/test_files.py
@@ -57,6 +57,9 @@ def test_remove_before_time_with_file_changes(directory):
 
     filenames = files.get_directory_filenames(directory_name=directory.name)
 
+    # Assume simulation takes at least 1 milisecond
+    time.sleep(0.001)
+
     modified_files = [filenames[0], filenames[-1]]
     for modified_file in modified_files:
         with open(modified_file, "a", encoding="utf-8") as file:

--- a/task-runner/tests/unit/test_files.py
+++ b/task-runner/tests/unit/test_files.py
@@ -3,27 +3,28 @@ import random
 import string
 import tempfile
 import time
-import pytest
 
+import pytest
 from task_runner.utils import files
 
 
 @pytest.fixture(name="directory", scope="function")
 def fixture_directory():
+
     def random_string():
         return ''.join(random.choices(string.ascii_letters, k=10))
-    
+
     def create_random_files(subdir_path, num_files):
         for _ in range(num_files):
             file_name = random_string() + '.txt'
             file_path = os.path.join(subdir_path, file_name)
-            with open(file_path, 'w') as f:
+            with open(file_path, 'w', encoding="utf-8") as f:
                 f.write(random_string())
 
     temporary_directory = tempfile.TemporaryDirectory(delete=False)
 
     create_random_files(temporary_directory.name, 3)
-    
+
     subdir_name = random_string()
     subdir_path = os.path.join(temporary_directory.name, subdir_name)
     os.makedirs(subdir_path)
@@ -53,16 +54,16 @@ def test_remove_before_time_with_file_changes(directory):
     start_time = time.time()
 
     filenames = get_directory_filenames(directory_name=directory.name)
-    
+
     modified_files = [filenames[0], filenames[-1]]
     for modified_file in modified_files:
-        with open(modified_file, "a") as file:
+        with open(modified_file, "a", encoding="utf-8") as file:
             file.write("\n")
-    
+
     created_file = os.path.join(os.path.dirname(modified_files[0]), "new.txt")
-    with open(created_file, "w") as file:
+    with open(created_file, "w", encoding="utf-8") as file:
         file.write("\n")
-    
+
     removed = files.remove_before_time(directory=directory.name,
                                        reference_time=start_time)
     assert len(removed) == 3
@@ -72,4 +73,3 @@ def test_remove_before_time_with_file_changes(directory):
     assert created_file in filenames
     assert modified_files[0] in filenames
     assert modified_files[1] in filenames
-

--- a/task-runner/tests/unit/test_files.py
+++ b/task-runner/tests/unit/test_files.py
@@ -1,0 +1,74 @@
+import os
+import random
+import string
+import tempfile
+import time
+import pytest
+
+from task_runner.utils import files
+
+
+@pytest.fixture(name="directory", scope="function")
+def fixture_directory():
+    def random_string():
+        return ''.join(random.choices(string.ascii_letters, k=10))
+    
+    def create_random_files(subdir_path, num_files):
+        for _ in range(num_files):
+            file_name = random_string() + '.txt'
+            file_path = os.path.join(subdir_path, file_name)
+            with open(file_path, 'w') as f:
+                f.write(random_string())
+
+    temporary_directory = tempfile.TemporaryDirectory(delete=False)
+
+    create_random_files(temporary_directory.name, 3)
+    
+    subdir_name = random_string()
+    subdir_path = os.path.join(temporary_directory.name, subdir_name)
+    os.makedirs(subdir_path)
+
+    create_random_files(subdir_path, 2)
+
+    yield temporary_directory
+    temporary_directory.cleanup()
+
+
+def test_remove_before_time_without_file_changes(directory):
+    start_time = time.time()
+    removed = files.remove_before_time(directory=directory.name,
+                                       reference_time=start_time)
+    assert len(removed) == 5
+
+
+def test_remove_before_time_with_file_changes(directory):
+    start_time = time.time()
+
+    filenames = [
+        os.path.join(path, filename)
+        for path, _, filenames in os.walk(directory.name)
+        for filename in filenames
+    ]
+    modified_files = [filenames[0], filenames[-1]]
+    for modified_file in modified_files:
+        with open(modified_file, "a") as file:
+            file.write("\n")
+    
+    created_file = os.path.join(os.path.dirname(modified_files[0]), "new.txt")
+    with open(created_file, "w") as file:
+        file.write("\n")
+    
+    removed = files.remove_before_time(directory=directory.name,
+                                       reference_time=start_time)
+    assert len(removed) == 3
+
+    filenames = [
+        os.path.join(path, filename)
+        for path, _, filenames in os.walk(directory.name)
+        for filename in filenames
+    ]
+
+    assert created_file in filenames
+    assert modified_files[0] in filenames
+    assert modified_files[1] in filenames
+

--- a/task-runner/tests/unit/test_files.py
+++ b/task-runner/tests/unit/test_files.py
@@ -48,7 +48,7 @@ def test_remove_before_time_without_file_changes(directory):
     Test that all files in the directory are removed when no files are
     modified or created after the reference time.
     """
-    start_time_ns = time.perf_counter()
+    start_time_ns = time.time_ns()
     removed = files.remove_before_time(directory=directory.name,
                                        reference_time_ns=start_time_ns)
     after = get_directory_filenames(directory_name=directory.name)
@@ -61,7 +61,7 @@ def test_remove_before_time_with_file_changes(directory):
     Test that only files created or modified after the reference time remain in 
     the directory.
     """
-    start_time_ns = time.perf_counter()
+    start_time_ns = time.time_ns()
 
     filenames = get_directory_filenames(directory_name=directory.name)
 

--- a/task-runner/tests/unit/test_files.py
+++ b/task-runner/tests/unit/test_files.py
@@ -44,6 +44,10 @@ def get_directory_filenames(directory_name):
 
 
 def test_remove_before_time_without_file_changes(directory):
+    """
+    Test that all files in the directory are removed when no files are
+    modified or created after the reference time.
+    """
     start_time_ns = time.time_ns()
     removed = files.remove_before_time(directory=directory.name,
                                        reference_time_ns=start_time_ns)
@@ -53,6 +57,10 @@ def test_remove_before_time_without_file_changes(directory):
 
 
 def test_remove_before_time_with_file_changes(directory):
+    """
+    Test that only files created or modified after the reference time remain in 
+    the directory.
+    """
     start_time_ns = time.time_ns()
 
     filenames = get_directory_filenames(directory_name=directory.name)

--- a/task-runner/tests/unit/test_files.py
+++ b/task-runner/tests/unit/test_files.py
@@ -48,9 +48,9 @@ def test_remove_before_time_without_file_changes(directory):
     Test that all files in the directory are removed when no files are
     modified or created after the reference time.
     """
-    start_time_ns = time.time_ns()
+    start_time_ms = time.time() * 1_000_000
     removed = files.remove_before_time(directory=directory.name,
-                                       reference_time_ns=start_time_ns)
+                                       reference_time_ms=start_time_ms)
     after = get_directory_filenames(directory_name=directory.name)
     assert len(removed) == 5
     assert len(after) == 0
@@ -61,7 +61,7 @@ def test_remove_before_time_with_file_changes(directory):
     Test that only files created or modified after the reference time remain in 
     the directory.
     """
-    start_time_ns = time.time_ns()
+    start_time_ms = time.time() * 1_000_000
 
     filenames = get_directory_filenames(directory_name=directory.name)
 
@@ -75,7 +75,7 @@ def test_remove_before_time_with_file_changes(directory):
         file.write("\n")
 
     removed = files.remove_before_time(directory=directory.name,
-                                       reference_time_ns=start_time_ns)
+                                       reference_time_ms=start_time_ms)
     assert len(removed) == 3
 
     filenames = get_directory_filenames(directory_name=directory.name)


### PR DESCRIPTION
Closes: [#813](https://github.com/inductiva/tasks/issues/813)

Implements filtering mechanism on output files based on timestamps of created and modified files.

Note: log files are never deleted because they are always created by us.