### PR TITLE
Add default folder

### DIFF
--- a/task-runner/task_runner/apptainer_utils.py
+++ b/task-runner/task_runner/apptainer_utils.py
@@ -16,6 +16,7 @@ from absl import logging
 import task_runner
 
 INDUCTIVA_IMAGE_PREFIX = "inductiva://"
+INDUCTIVA_USER_STORAGE_DEFAULT_FOLDER = "my-containers"
 
 
 class ApptainerImageSource(enum.Enum):
@@ -187,7 +188,11 @@ class ApptainerImagesManager:
     def _parse_inductiva_uri(self, image: str) -> tuple[str, str]:
         """Extracts the bucket and file path from an Inductiva URI."""
         try:
-            return image.removeprefix(INDUCTIVA_IMAGE_PREFIX)
+            path = image.removeprefix(INDUCTIVA_IMAGE_PREFIX)
+            if "/" not in path:
+                # User provided just the image name -> use default folder
+                path = os.path.join(INDUCTIVA_USER_STORAGE_DEFAULT_FOLDER, path)
+            return path
         except ValueError:
             raise ApptainerImageNotFoundError(
                 f"Invalid Inductiva image format: {image}")

--- a/task-runner/task_runner/apptainer_utils.py
+++ b/task-runner/task_runner/apptainer_utils.py
@@ -185,7 +185,7 @@ class ApptainerImagesManager:
         except Exception:  # noqa BLE001
             return False
 
-    def _parse_inductiva_uri(self, image: str) -> tuple[str, str]:
+    def _parse_inductiva_uri(self, image: str) -> str:
         """Extracts the bucket and file path from an Inductiva URI."""
         try:
             path = image.removeprefix(INDUCTIVA_IMAGE_PREFIX)


### PR DESCRIPTION
Users can now input

inductiva://private_image.sif, where it will look at users' "my-container" default folder.

This PR is to make the behavior consistent with the CLI usage, where users can do:

inductiva containers upload private_image, and it will be uploaded to "my-containers" default folder. 

Therefore, we need to allow for users to omit the my-containers folder here. 