### PR TITLE
Implements streaming of 7z standard output

### DIFF
--- a/task-runner/task_runner/utils/files.py
+++ b/task-runner/task_runner/utils/files.py
@@ -198,6 +198,16 @@ def get_seven_zip_stream_process(
     ZIP archive and returns a process object. The process will write to
     standard output and is configured with the specified buffer size.
     Use the process standard output as a stream.
+    
+    7z arguments used:
+        a       : Add files to archive.
+        -tzip   : Set the archive type to ZIP.
+        -mx=1   : Set compression level to 1 (fastest).
+        -mmt=on : Enable multithreading.
+        -bso0   : Disable standard output messages.
+        -bsp0   : Disable progress indicator on standard error.
+        -so     : Write the archive to standard output.
+        -an     : Disable archive name (used when outputting to stdout).
     """
     args = [
         "7z", "a", "-tzip", "-mx=1", "-mmt=on", "-bso0", "-bsp0", "-so", "-an",

--- a/task-runner/task_runner/utils/files.py
+++ b/task-runner/task_runner/utils/files.py
@@ -189,6 +189,23 @@ def get_zip_files(paths, chunk_size):
         ) for path in paths)
 
 
+def get_seven_zip_stream_process(
+        local_path: str,
+        bufsize: int = 4 * 1024 * 1024,  # 4 MB
+) -> subprocess.Popen:
+    """
+    This function invokes the 7z command-line utility to compress files into a
+    ZIP archive and returns a process object. The process will write to
+    standard output and is configured with the specified buffer size.
+    Use the process standard output as a stream.
+    """
+    args = [
+        "7z", "a", "-tzip", "-mx=1", "-mmt=on", "-bso0", "-bsp0", "-so", "-an",
+        local_path
+    ]
+    return subprocess.Popen(args, bufsize, stdout=subprocess.PIPE)
+
+
 def get_zip_generator(
     local_path: str,
     zip_chunk_size: int = DEFAULT_ZIP_CHUNK_SIZE_BYTES,


### PR DESCRIPTION
This implementation streams the output of 7z directly into the upload request, removing the need to store the zipped file on disk.

We now support 4 compression/upload methods:

```python
simulator.run(..., stream_zip=True, compress_with="SEVEN_ZIP") # Streams 7z
simulator.run(..., stream_zip=False, compress_with="SEVEN_ZIP") # Compresses using 7z, then uploads
simulator.run(..., stream_zip=True, compress_with="AUTO") # Streams using the default ZIP method
simulator.run(..., stream_zip=False, compress_with="AUTO") # Compresses using the default ZIP method, then uploads
```

Related to: https://github.com/inductiva/tasks/issues/722