### PR TITLE
Replace 7z by 7zz for streaming 7z outputs in Docker

### DIFF
--- a/task-runner/Dockerfile
+++ b/task-runner/Dockerfile
@@ -6,7 +6,12 @@ ENV EXECUTER_IMAGES_DIR=/executer-images
 ARG API_URL=https://api.inductiva.ai
 ENV API_URL=${API_URL}
 
-RUN apt-get update && apt-get install -y wget p7zip-full
+RUN apt-get update && apt-get install -y wget
+
+RUN wget https://www.7-zip.org/a/7z2409-linux-x64.tar.xz && \
+    tar -xf 7z2409-linux-x64.tar.xz && \
+    mv 7zz /usr/local/bin/ && chmod +x /usr/local/bin/7zz && \
+    rm -rf 7z2301-linux-x64.tar.xz
 
 RUN cd /tmp \
     && wget https://github.com/apptainer/apptainer/releases/download/v1.3.3/apptainer_1.3.3_amd64.deb \

--- a/task-runner/Dockerfile.lite
+++ b/task-runner/Dockerfile.lite
@@ -2,7 +2,12 @@ FROM python:3.9
 
 ENV LOCAL_MODE true
 
-RUN apt-get update && apt-get install -y wget p7zip-full
+RUN apt-get update && apt-get install -y wget
+
+RUN wget https://www.7-zip.org/a/7z2409-linux-x64.tar.xz && \
+    tar -xf 7z2409-linux-x64.tar.xz && \
+    mv 7zz /usr/local/bin/ && chmod +x /usr/local/bin/7zz && \
+    rm -rf 7z2301-linux-x64.tar.xz
 
 RUN cd /tmp \
     && wget https://github.com/apptainer/apptainer/releases/download/v1.3.3/apptainer_1.3.3_amd64.deb \

--- a/task-runner/task_runner/utils/files.py
+++ b/task-runner/task_runner/utils/files.py
@@ -313,7 +313,7 @@ def compress_with_seven_z(
 ) -> str:
     zip_path = f"/tmp/{archive_name}"
     args = [
-        "7z", "a", "-tzip", f"-mx={compression_level}", "-mmt=on", zip_path,
+        "7zz", "a", "-tzip", f"-mx={compression_level}", "-mmt=on", zip_path,
         directory_name, "-bso0", "-bsp0"
     ]
     subprocess.run(args, check=True)

--- a/task-runner/task_runner/utils/files.py
+++ b/task-runner/task_runner/utils/files.py
@@ -210,7 +210,7 @@ def get_seven_zip_stream_process(
         -an     : Disable archive name (used when outputting to stdout).
     """
     args = [
-        "7z", "a", "-tzip", "-mx=1", "-mmt=on", "-bso0", "-bsp0", "-so", "-an",
+        "7zz", "a", "-tzip", "-mx=1", "-mmt=on", "-bso0", "-bsp0", "-so", "-an",
         local_path
     ]
     return subprocess.Popen(args, bufsize, stdout=subprocess.PIPE)


### PR DESCRIPTION
Enables streaming of 7z outputs in Docker -- it switches to 7zz (official, most modern version).
