### PR TITLE
Retry Output Uploads on HTTP Errors

### DIFF
--- a/task-runner/requirements.txt
+++ b/task-runner/requirements.txt
@@ -7,4 +7,4 @@ gcsfs
 stream-zip==0.0.81
 pysocks
 gputil
-urllib3
+tenacity

--- a/task-runner/requirements.txt
+++ b/task-runner/requirements.txt
@@ -7,3 +7,4 @@ gcsfs
 stream-zip==0.0.81
 pysocks
 gputil
+urllib3

--- a/task-runner/task_runner/file_manager.py
+++ b/task-runner/task_runner/file_manager.py
@@ -186,7 +186,7 @@ class WebApiFileManager(BaseFileManager):
 
         operation = operations_logger.start_operation(
             OperationName.UPLOAD_OUTPUT, task_id)
-        resp, upload_time = WebApiFileManager.upload(
+        resp, upload_time = WebApiFileManager.retry_upload(
             method=upload_info.method,
             url=upload_info.url,
             data=data,

--- a/task-runner/task_runner/file_manager.py
+++ b/task-runner/task_runner/file_manager.py
@@ -122,7 +122,7 @@ class WebApiFileManager(BaseFileManager):
             task_runner_uuid: uuid.UUID,
             event_logger: task_runner.BaseEventLogger) -> requests.Response:
         for attempt in tenacity.Retrying(
-                stop=tenacity.stop_never,
+                stop=tenacity.stop_after_attempt(5),
                 wait=tenacity.wait_exponential(),
                 before_sleep=WebApiFileManager.make_fail_upload_hook(
                     task_id=task_id,

--- a/task-runner/task_runner/file_manager.py
+++ b/task-runner/task_runner/file_manager.py
@@ -81,7 +81,7 @@ class Retry(urllib3.Retry):
             backoff_factor=backoff_factor,
         )
         self.task_id = task_id
-        self.task_runner_uuid = self.task_runner_uuid
+        self.task_runner_uuid = task_runner_uuid
         self.event_logger = event_logger
 
     def increment(

--- a/task-runner/task_runner/file_manager.py
+++ b/task-runner/task_runner/file_manager.py
@@ -123,7 +123,7 @@ class WebApiFileManager(BaseFileManager):
             event_logger: task_runner.BaseEventLogger) -> requests.Response:
         for attempt in tenacity.Retrying(
                 stop=tenacity.stop_after_attempt(5),
-                wait=tenacity.wait_exponential(),
+                wait=tenacity.wait_exponential(multiplier=10),
                 before_sleep=WebApiFileManager.make_fail_upload_hook(
                     task_id=task_id,
                     task_runner_uuid=task_runner_uuid,

--- a/task-runner/task_runner/file_manager.py
+++ b/task-runner/task_runner/file_manager.py
@@ -2,6 +2,7 @@ import abc
 import os
 import pathlib
 import traceback
+import types
 import typing
 import urllib
 import urllib.request
@@ -91,7 +92,7 @@ class Retry(urllib3.Retry):
         response: urllib3.BaseHTTPResponse | None = None,
         error: Exception | None = None,
         pool: urllib3.connectionpool.ConnectionPool | None = None,
-        stacktrace: typing.TracebackType | None = None,
+        stacktrace: types.TracebackType | None = None,
     ) -> typing.Self:
         self._handle_retry(method, url, response, error, pool, stacktrace)
         new = super().increment(method, url, response, error, pool, stacktrace)
@@ -104,7 +105,7 @@ class Retry(urllib3.Retry):
         response: urllib3.BaseHTTPResponse | None = None,
         error: Exception | None = None,
         pool: urllib3.connectionpool.ConnectionPool | None = None,
-        stacktrace: typing.TracebackType | None = None,
+        stacktrace: types.TracebackType | None = None,
     ):
         message = utils.get_exception_root_cause_message(error)
         self.event_logger.log(

--- a/task-runner/task_runner/file_manager.py
+++ b/task-runner/task_runner/file_manager.py
@@ -115,7 +115,6 @@ class WebApiFileManager(BaseFileManager):
 
         return fail_upload_hook
 
-
     @staticmethod
     @utils.execution_time_with_result
     def retry_upload(

--- a/task-runner/task_runner/file_manager.py
+++ b/task-runner/task_runner/file_manager.py
@@ -131,7 +131,7 @@ class WebApiFileManager(BaseFileManager):
 
     @staticmethod
     @utils.execution_time_with_result
-    async def retry_upload(
+    def retry_upload(
             method: str, url: str, data, task_id: str,
             task_runner_uuid: uuid.UUID,
             event_logger: task_runner.BaseEventLogger) -> requests.Response:

--- a/task-runner/task_runner/task_request_handler.py
+++ b/task-runner/task_runner/task_request_handler.py
@@ -582,7 +582,7 @@ class TaskRequestHandler:
         if output_total_files is not None:
             self._post_task_metric(utils.OUTPUT_TOTAL_FILES, output_total_files)
 
-        output_zipped_bytes, zip_duration, upload_duration = (
+        output_zipped_bytes, zip_duration, upload_duration = \
             self.file_manager.upload_output(
                 self.task_id,
                 self.task_dir_remote,
@@ -590,7 +590,8 @@ class TaskRequestHandler:
                 stream_zip=self.stream_zip,
                 compress_with=self.compress_with,
                 operations_logger=self._operations_logger,
-            ))
+                event_logger=self.event_logger,
+            )
 
         logging.info("Output zipped in: %s seconds", zip_duration)
 

--- a/task-runner/task_runner/task_request_handler.py
+++ b/task-runner/task_runner/task_request_handler.py
@@ -393,7 +393,7 @@ class TaskRequestHandler:
                 self._publish_event(
                     events.TaskOutputUploadFailed(
                         id=self.task_id,
-                        machine_id=self.executer_uuid,
+                        machine_id=self.task_runner_uuid,
                         error_message=message,
                         traceback=traceback.format_exc(),
                     ))

--- a/task-runner/task_runner/task_request_handler.py
+++ b/task-runner/task_runner/task_request_handler.py
@@ -591,6 +591,7 @@ class TaskRequestHandler:
                 compress_with=self.compress_with,
                 operations_logger=self._operations_logger,
                 event_logger=self.event_logger,
+                task_runner_uuid=self.task_runner_uuid,
             )
 
         logging.info("Output zipped in: %s seconds", zip_duration)


### PR DESCRIPTION
Closes https://github.com/inductiva/tasks/issues/1089.

Adds retry logic for output uploads using [tenacity](https://github.com/jd/tenacity), which has a nicer and more flexible interface than our current `@utils.retry`. Might be worth replacing our custom retry with this across the codebase later on.

**Tests**:

1) To test the retry mechanism, I generated a signed URL for downloading, which triggers a 403 error when used for uploading.

```python
import uuid
from task_runner import event_logger, file_manager
from task_runner.utils import files

URL = "<download-signed-url>"

class MockEventLogger(event_logger.BaseEventLogger):
    def log(self, event):
        print(event)

stream_process = files.get_seven_zip_stream_process(
    "../benchmark-upload-of-task-runner-outputs/myfolder")
data = stream_process.stdout

response = file_manager.WebApiFileManager.retry_upload(
    method="PUT",
    url=URL,
    data=data,
    task_id="id",
    task_runner_uuid=uuid.uuid4(),
    event_logger=MockEventLogger(),
)

print(response)
```

2) For safety, I also ran a benchmark, but as expected, this had no impact on performance.

```python
import uuid
from task_runner import event_logger, file_manager, utils
from task_runner.utils import files


URL = "<upload-signed-url>"

@utils.execution_time_with_result
def upload_no_retry(url, data):
    return file_manager.WebApiFileManager.upload("PUT", url, data)


class MockEventLogger(event_logger.BaseEventLogger):
    def log(self, event):
        print(event)


if __name__ == "__main__":
    local_path = "<10GB-output-folder>"

    stream_process = files.get_seven_zip_stream_process(local_path)
    r1, t1 = upload_no_retry(URL, stream_process.stdout)

    assert r1.status_code == 200

    print(r1, t1)
    # <Response [200]> 220.21145510673523

    stream_process = files.get_seven_zip_stream_process(local_path)
    r2, t2 = file_manager.WebApiFileManager.retry_upload(
        method="PUT",
        url=URL,
        data=stream_process.stdout,
        task_id="id",
        task_runner_uuid=uuid.uuid4(),
        event_logger=MockEventLogger(),
    )

    assert r2.status_code == 200

    print(r2, t2)
    # <Response [200]> 198.83276176452637
```

Note: During benchmarking, the upload raised an exception that wasn't among the expected HTTPError types (it was a `requests.exceptions.SSLError`). So, I decided to catch **all** exceptions during upload (check this [commit](https://github.com/inductiva/task-runner/pull/161/commits/c2eb36c6cd5f1088ce41cabdcaa527cb4879c322))
