### PR TITLE
Update apptainer command and fix input files ownership

### DIFF
--- a/task-runner/task_runner/executers/arbitrary_commands_executer.py
+++ b/task-runner/task_runner/executers/arbitrary_commands_executer.py
@@ -24,9 +24,7 @@ class ArbitraryCommandsExecuter(executers.BaseExecuter):
         shutil.copytree(input_dir, self.artifacts_dir, dirs_exist_ok=True)
 
         if self.commands_user:
-            os.system(
-                f"chown -R {self.commands_user}:task-runner-group {self.working_dir}"
-            )
+            os.system(f"sudo chown -R {self.commands_user} {self.working_dir}")
 
         # Save this timestamp to detect which files were created or modified
         timestamp = files.get_most_recent_timestamp(self.artifacts_dir)

--- a/task-runner/task_runner/executers/base_executer.py
+++ b/task-runner/task_runner/executers/base_executer.py
@@ -263,7 +263,10 @@ class BaseExecuter(ABC):
             apptainer_args = [
                 "apptainer",
                 "exec",
-                "--contain",
+                "--no-mount",
+                "cwd",
+                "--home",
+                "/home/apptainer",
                 "--bind",
                 f"{task_working_dir_host}:{task_working_dir_container}",
                 "--pwd",


### PR DESCRIPTION
- Fix ownership of files in case a separate user is used to run the commands so that user commands can use chmod
- Don't mount the home directory of the host to the container