### PR TITLE
Add parameters to SystemMonitor class

### DIFF
--- a/task-runner/task_runner/task_request_handler.py
+++ b/task-runner/task_runner/task_request_handler.py
@@ -659,6 +659,7 @@ class TaskRequestHandler:
             Python command to execute received request.
         """
         simulator = request["simulator"]
+        container_image = request["container_image"]
 
         executer_class = api_methods_config.get_executer(simulator)
         if executer_class is None:
@@ -676,5 +677,7 @@ class TaskRequestHandler:
                 task_id=self.task_id,
                 task_runner_uuid=self.task_runner_uuid,
                 event_logger=self.event_logger,
+                output_stalled_threshold_minutes=None
+                if "openfast" in container_image else 30,
             ),
         )


### PR DESCRIPTION
This PR is a temporary fix to avoid false alerts of task output stalled for openfast simulator. In the final solution the additional parameters will be explicitly sent to the BE by the python client.